### PR TITLE
Raises ValueError if # of clicks and stimuli do not match

### DIFF
--- a/dlab/kilo.py
+++ b/dlab/kilo.py
@@ -148,8 +148,11 @@ def oeaudio_to_trials(
         logging.info("  - recording clock offset: %d", stim_sample_offset)
 
         if len(entry_stimuli) != stim_onsets.size:
-            logging.warning(
-                "  - WARNING: number of stimuli does not match number of clicks. This recording may need to be discarded"
+            logging.error(
+                "  - Numer of stimuli: %s is different from number of clicks: %s" % (len(entry_stimuli), stim_onsets.size)
+            )
+            raise ValueError(
+                "  - Error: number of stimuli not equal to number of clicks. Either discard recording or change sync threshold."
             )
 
         padding_samples = int(prepad * sampling_rate)


### PR DESCRIPTION
Change from a warning to an error, since a mismatch between sync counts and trial counts will lead to errors later in the scripts. The intent is for the user to examine the 'sync' channel signal to account for "pop"s that can throw off the spike detector. 